### PR TITLE
chore+fix/http

### DIFF
--- a/packages/smart_http/CHANGELOG.md
+++ b/packages/smart_http/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.2]
+
+* chore: made `HttpClient.decodeErrorData` public.
+* chore: moved `CancelableBlocMixin.tryIt` to extension method.
+* chore: made `HttpClientConfig` equatable.
+* fix: handled type casting issue in `HttpClient.decodeData` which will throw a `TypeMismatchException` with the data that was unable to cast.
+
 ## [1.0.1]
 
 * chore: made `decodeErrorMessage` public.

--- a/packages/smart_http/lib/src/cancelable.dart
+++ b/packages/smart_http/lib/src/cancelable.dart
@@ -31,24 +31,6 @@ mixin CancelableBlocMixin {
 
   /// Cancels all the pending data requests in the current repository.
   Future<void> cancel() => repository.cancel();
-
-  /// Provides a helper method to try-catch by separate handling of
-  /// [CancelException] with [onCancel] callback.
-  Future<void> tryIt(
-    Future<dynamic> Function() task, {
-    required void Function(dynamic) catchError,
-    void Function()? onCancel,
-  }) async {
-    try {
-      await task();
-    } catch (e) {
-      if (e is CancelException) {
-        onCancel?.call();
-        return;
-      }
-      catchError(e);
-    }
-  }
 }
 
 /// An abstraction that enables cancelable cubit to cancel the pending data
@@ -82,5 +64,25 @@ abstract class CancelableBloc<Event, State> extends Bloc<Event, State>
   Future<void> close() async {
     await cancel();
     return super.close();
+  }
+}
+
+extension CancelableBlocTry<State> on BlocBase<State> {
+  /// Provides a helper method to try-catch by separate handling of
+  /// [CancelException] with [onCancel] callback.
+  Future<void> tryIt(
+    Future<dynamic> Function() task, {
+    required void Function(dynamic) catchError,
+    void Function()? onCancel,
+  }) async {
+    try {
+      await task();
+    } catch (e) {
+      if (e is CancelException) {
+        onCancel?.call();
+        return;
+      }
+      catchError(e);
+    }
   }
 }

--- a/packages/smart_http/lib/src/http_client_config.dart
+++ b/packages/smart_http/lib/src/http_client_config.dart
@@ -1,9 +1,11 @@
+import 'package:equatable/equatable.dart';
+
 /// Configure Http properties to be used later on
 /// thoroughout Http calls
 ///
 /// Though for a specific use case these can also be
 /// overriden in http request functions
-class HttpClientConfig {
+class HttpClientConfig extends Equatable {
   const HttpClientConfig({
     this.baseUrl = '',
     this.headers,
@@ -52,4 +54,14 @@ class HttpClientConfig {
   /// Enable logs for the api calls in the project
   /// Defaults to `false`
   final bool enableLogs;
+
+  @override
+  List<Object?> get props => [
+        baseUrl,
+        headers,
+        connectTimeout,
+        sendTimeout,
+        receiveTimeout,
+        enableLogs,
+      ];
 }

--- a/packages/smart_http/lib/src/models/http_exception.dart
+++ b/packages/smart_http/lib/src/models/http_exception.dart
@@ -5,33 +5,45 @@ class HttpException extends Equatable implements Exception {
   const HttpException([
     this._message,
     this._prefix = '',
+    this._data,
   ]);
 
   HttpException copyWith({
     String? message,
     String? prefix,
+    dynamic data,
   }) {
     return HttpException(
       message ?? _message,
       prefix ?? _prefix,
+      data ?? _data,
     );
   }
 
   final String? _message;
   final String _prefix;
+  final dynamic _data;
 
   String get message => _message ?? 'Something went wrong!';
+
+  dynamic get data => _data;
 
   @override
   String toString() => '$_prefix$_message';
 
   @override
-  List<Object?> get props => [_message, _prefix];
+  List<Object?> get props => [_message, _prefix, _data];
 }
 
 class NoDataException extends HttpException {
   const NoDataException([String prefix = ''])
       : super('Something went wrong, please try again later.', prefix);
+}
+
+class TypeMismatchException extends HttpException {
+  TypeMismatchException([dynamic data])
+      : super(data?.toString() ?? 'Type used is not matching the expected one.',
+            '', data);
 }
 
 class InternalServerException extends HttpException {

--- a/packages/smart_http/pubspec.yaml
+++ b/packages/smart_http/pubspec.yaml
@@ -3,7 +3,7 @@ description: A dart wrapper around dio to handle http requests along with cancel
 homepage: https://github.com/asadbaidar/smart
 repository: https://github.com/asadbaidar/smart/tree/master/packages/smart_http
 
-version: 1.0.1
+version: 1.0.2
 
 environment:
   sdk: ">=3.4.4 <4.0.0"


### PR DESCRIPTION
* chore: made `HttpClient.decodeErrorData` public.
* chore: moved `CancelableBlocMixin.tryIt` to extension method.
* chore: made `HttpClientConfig` equatable.
* fix: handled type casting issue in `HttpClient.decodeData` which will throw a `TypeMismatchException` with the data that was unable to cast.