### PR TITLE
chore+fix/http_errors

### DIFF
--- a/packages/smart_http/CHANGELOG.md
+++ b/packages/smart_http/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.0.3]
+
+* chore: made `HttpClient.mapError` public.
+* chore: added `HttpException.code` to set http status codes.
+* fix: used the original http error message when passing to `HttpException` instead of a default message
+
 ## [1.0.2]
 
 * chore: made `HttpClient.decodeErrorData` public.

--- a/packages/smart_http/lib/src/models/http_exception.dart
+++ b/packages/smart_http/lib/src/models/http_exception.dart
@@ -5,26 +5,32 @@ class HttpException extends Equatable implements Exception {
   const HttpException([
     this._message,
     this._prefix = '',
+    this._code = 0,
     this._data,
   ]);
 
   HttpException copyWith({
     String? message,
     String? prefix,
+    int? code,
     dynamic data,
   }) {
     return HttpException(
       message ?? _message,
       prefix ?? _prefix,
+      code ?? _code,
       data ?? _data,
     );
   }
 
   final String? _message;
   final String _prefix;
+  final int _code;
   final dynamic _data;
 
   String get message => _message ?? 'Something went wrong!';
+
+  int get code => _code;
 
   dynamic get data => _data;
 
@@ -32,25 +38,30 @@ class HttpException extends Equatable implements Exception {
   String toString() => '$_prefix$_message';
 
   @override
-  List<Object?> get props => [_message, _prefix, _data];
+  List<Object?> get props => [_message, _prefix, _code, _data];
+}
+
+class NotFoundException extends HttpException {
+  const NotFoundException([String? message])
+      : super(message ?? 'Resource not found.', '', 404);
 }
 
 class NoDataException extends HttpException {
-  const NoDataException([String prefix = ''])
-      : super('Something went wrong, please try again later.', prefix);
+  const NoDataException(int code, [String? message])
+      : super(message ?? 'Something went wrong, please try again later.', '',
+            code);
 }
 
 class TypeMismatchException extends HttpException {
   TypeMismatchException([dynamic data])
       : super(data?.toString() ?? 'Type used is not matching the expected one.',
-            '', data);
+            '', 200, data);
 }
 
 class InternalServerException extends HttpException {
   const InternalServerException([String? message])
-      : super(
-          message ?? 'Unable to make a connection, please try again later.',
-        );
+      : super(message ?? 'Unable to make a connection, please try again later.',
+            '', 500);
 }
 
 class NoInternetException extends HttpException {
@@ -62,12 +73,12 @@ class NoInternetException extends HttpException {
 
 class BadRequestException extends HttpException {
   const BadRequestException([String? message])
-      : super(message, 'Invalid Request: ');
+      : super(message, 'Invalid Request: ', 400);
 }
 
 class UnauthorisedException extends HttpException {
-  const UnauthorisedException([String? message])
-      : super(message, 'Unauthorised: ');
+  const UnauthorisedException(int code, [String? message])
+      : super(message, 'Unauthorised: ', code);
 }
 
 class TimeoutException extends HttpException {

--- a/packages/smart_http/pubspec.yaml
+++ b/packages/smart_http/pubspec.yaml
@@ -3,7 +3,7 @@ description: A dart wrapper around dio to handle http requests along with cancel
 homepage: https://github.com/asadbaidar/smart
 repository: https://github.com/asadbaidar/smart/tree/master/packages/smart_http
 
-version: 1.0.2
+version: 1.0.3
 
 environment:
   sdk: ">=3.4.4 <4.0.0"


### PR DESCRIPTION
* chore: made `HttpClient.mapError` public.
* chore: added `HttpException.code` to set http status codes.
* fix: used the original http error message when passing to `HttpException` instead of a default message