### PR TITLE
chore/utils_lifecycle_observer

### DIFF
--- a/packages/smart_flutter_utils/CHANGELOG.md
+++ b/packages/smart_flutter_utils/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [1.0.5]
 
 * fix: fixed `BlocBase.when` method where it was ignoring the previous state changes in the next state emits.
+* chore: Added simplified `LifecycleObserver` to observe the lifecycle of a widget including app lifecycle.
 
 ## [1.0.4]
 

--- a/packages/smart_flutter_utils/lib/src/utils/lifecycle_observer.dart
+++ b/packages/smart_flutter_utils/lib/src/utils/lifecycle_observer.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+
+class LifecycleObserver extends StatefulWidget {
+  const LifecycleObserver({
+    super.key,
+    this.onInit,
+    this.onInitiated,
+    this.onResumed,
+    this.onDetached,
+    this.onInactive,
+    this.onHidden,
+    this.onPaused,
+    this.onDisposed,
+    this.rebuildOnResume = false,
+    this.child,
+    this.builder,
+  });
+
+  final VoidCallback? onInit;
+  final VoidCallback? onInitiated;
+  final VoidCallback? onResumed;
+  final VoidCallback? onDetached;
+  final VoidCallback? onInactive;
+  final VoidCallback? onHidden;
+  final VoidCallback? onPaused;
+  final VoidCallback? onDisposed;
+  final bool rebuildOnResume;
+  final Widget? child;
+  final WidgetBuilder? builder;
+
+  @override
+  State<LifecycleObserver> createState() => _LifecycleObserverState();
+}
+
+class _LifecycleObserverState extends State<LifecycleObserver> {
+  late final LifecycleCallbackHandler? handler;
+
+  bool get requiredAppLifecycle =>
+      widget.rebuildOnResume ||
+      widget.onResumed != null ||
+      widget.onDetached != null ||
+      widget.onInactive != null ||
+      widget.onHidden != null ||
+      widget.onPaused != null;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.onInit?.call();
+    if (widget.onInitiated != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        widget.onInitiated?.call();
+      });
+    }
+    if (requiredAppLifecycle) {
+      handler = LifecycleCallbackHandler(
+        onResumed: _onResumed,
+        onDetached: widget.onDetached,
+        onInactive: widget.onInactive,
+        onHidden: widget.onHidden,
+        onPaused: widget.onPaused,
+      );
+      WidgetsBinding.instance.addObserver(handler!);
+    }
+  }
+
+  void _onResumed() {
+    widget.onResumed?.call();
+    if (widget.rebuildOnResume) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    widget.onDisposed?.call();
+    if (requiredAppLifecycle) {
+      WidgetsBinding.instance.removeObserver(handler!);
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      widget.builder?.call(context) ?? widget.child ?? const SizedBox.shrink();
+}
+
+class LifecycleCallbackHandler extends WidgetsBindingObserver {
+  LifecycleCallbackHandler({
+    this.onResumed,
+    this.onDetached,
+    this.onInactive,
+    this.onHidden,
+    this.onPaused,
+  });
+
+  final VoidCallback? onResumed;
+  final VoidCallback? onDetached;
+  final VoidCallback? onInactive;
+  final VoidCallback? onHidden;
+  final VoidCallback? onPaused;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.resumed:
+        onResumed?.call();
+      case AppLifecycleState.detached:
+        onDetached?.call();
+      case AppLifecycleState.inactive:
+        onInactive?.call();
+      case AppLifecycleState.hidden:
+        onHidden?.call();
+      case AppLifecycleState.paused:
+        onPaused?.call();
+    }
+  }
+}

--- a/packages/smart_flutter_utils/lib/src/utils/utils.dart
+++ b/packages/smart_flutter_utils/lib/src/utils/utils.dart
@@ -5,6 +5,7 @@ export 'date_time.dart';
 export 'debouncer.dart';
 export 'global.dart';
 export 'json.dart';
+export 'lifecycle_observer.dart';
 export 'logger.dart';
 export 'map_navigation.dart';
 export 'mapper.dart';


### PR DESCRIPTION
* chore: Added simplified `LifecycleObserver` to observe the lifecycle of a widget including app lifecycle.